### PR TITLE
update:単語入力に失敗した時のリダイレクト先を変更した

### DIFF
--- a/app/controllers/hiraganas_controller.rb
+++ b/app/controllers/hiraganas_controller.rb
@@ -16,8 +16,9 @@ class HiraganasController < ApplicationController
     if @hiragana.save
       redirect_to hiraganas_path, success: 'ひらがなを登録しました'
     else
+      @hiraganas = current_user.hiraganas.page(params[:page]).order(created_at: :desc)
       flash.now[:danger] = @hiragana.errors.messages.values.flatten.join(', ')
-      render :new, status: :unprocessable_entity
+      render :index, status: :unprocessable_entity
     end
   end
 


### PR DESCRIPTION
## 変更を加えたファイル
app/controllers/hiraganas_controller.rb


## やったこと

* このプルリクで何をしたのか？
単語入力に失敗した時のリダイレクト先をnewからindexに変更した。
indexページでフラッシュメッセージが出るようにしました。

## やらないこと

* このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。）

## できるようになること（ユーザ目線）

* 何ができるようになるのか？（あれば。無いなら「無し」でOK）
単語入力に失敗した時に、フラッシュメッセージで分かるようになった。
単語入力に失敗した時でも、そのままindexで入力を続けることができる。

## できなくなること（ユーザ目線）

* 何ができなくなるのか？（あれば。無いなら「無し」でOK）
なし

## 動作確認

* どのような動作確認を行ったのか？　結果はどうか？

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
