### PR TITLE
update:お試しページにバリデーションエラーメッセージが表示されるようになりました

### DIFF
--- a/app/controllers/hiraganas_controller.rb
+++ b/app/controllers/hiraganas_controller.rb
@@ -40,10 +40,23 @@ class HiraganasController < ApplicationController
     @sign_languages = characters.map { |char| SignLanguage.find_by(character: char) }
   end
 
-
   def trial
-    characters = params[:character]&.chars || []
-    @sign_languages = characters.map { |char| SignLanguage.find_by(character: char) }
+    if params[:character].present?
+      characters = params[:character].chars
+      @sign_languages = []
+      characters.each do |char|
+        hiragana = Hiragana.new(character: char)
+        if hiragana.valid?
+          @sign_languages << SignLanguage.find_by(character: char)
+        else
+          flash.now[:danger] = hiragana.errors.full_messages.join(', ')
+          @sign_languages = []
+          break
+        end
+      end
+    else
+      @sign_languages = []
+    end
   end
 
   def next


### PR DESCRIPTION
## 変更を加えたファイル
app/models/hiragana.rb
app/controllers/hiraganas_controller.rb

## やったこと

* このプルリクで何をしたのか？
お試しページに入力エラーのメッセージを表示されるようにした。

## やらないこと

* このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。）
なし

## できるようになること（ユーザ目線）

* 何ができるようになるのか？（あれば。無いなら「無し」でOK）
ひらがなで入力していない時、「ひらがなで入力して下さい」
「ゔ」を入力した時、「「ゔ」を含めることはできません」と表示されるようになり
ユーザーがどこに間違いがあるか把握しやすくなった。

## できなくなること（ユーザ目線）

* 何ができなくなるのか？（あれば。無いなら「無し」でOK）
なし

## 動作確認

* どのような動作確認を行ったのか？　結果はどうか？
デプロイ先で、お試しページの入力に失敗してみました。エラーのフラッシュメッセージが問題なく表示されました。
## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
